### PR TITLE
Fix recursive loop in into_result

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -30,8 +30,9 @@ macro_rules! scoped_ptr {
             ///
             /// # Errors
             /// When passed a null pointer generates an error.
-            pub unsafe fn from_ptr(ptr: *mut $target) -> Result<Self, $crate::err::Error> {
-                $crate::err::IntoResult::into_result(ptr)
+            pub unsafe fn from_ptr(raw: *mut $target) -> Result<Self, $crate::err::Error> {
+                let ptr = $crate::err::into_result(raw)?;
+                Ok(Self { ptr })
             }
         }
 


### PR DESCRIPTION
Trait implementation `into_result()` calls `from_ptr()` which calls trait implementation `into_result()` again.
Make `from_ptr()` call `err::into_result()` instead, to break the loop.