### PR TITLE
Add PK11_ImportSymKey needed by auth-rs

### DIFF
--- a/bindings/bindings.toml
+++ b/bindings/bindings.toml
@@ -182,6 +182,7 @@ functions = [
     "PK11_GetMechanism",
     "PK11_HPKE_Serialize",
     "PK11_ImportDataKey",
+    "PK11_ImportSymKey",
     "PK11_PubDeriveWithKDF",
     "PK11_ReadRawAttribute",
     "PK11_ReferenceSymKey",


### PR DESCRIPTION
Binding for `PK11_ImportSymKey` is needed in auth-rs.